### PR TITLE
fix: incorrect deepep buffer 'low_latency_mode' setting

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/token_dispatcher.py
+++ b/python/sglang/srt/layers/moe/ep_moe/token_dispatcher.py
@@ -87,7 +87,7 @@ class DeepEPBuffer:
             group,
             num_nvl_bytes,
             num_rdma_bytes,
-            low_latency_mode=deepep_mode.enable_low_latency(),
+            low_latency_mode=True,
             num_qps_per_rank=(
                 num_experts // group.size() if deepep_mode.enable_low_latency() else 1
             ),


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Through monitoring RDMA traffic, we discovered that during the ```dispatch``` process, all the traffic was concentrated on the first rdma card with the set of ```--deepep-mode normal``` on prefill node. After walking through the DeepEP coda and enable ```NVSHMEM_DEBUG=TRACE```, we found that the ```low_latency_mode``` arg in ```deep_ep.Buffer``` affects the NVSHMEM PE initialization. If set ```deep_ep.Buffer.low_latency_mode``` to ```False```, only one PE in each node. On the contrary, there are 8 PE on each node. To verify my hypothesis, I set the Buffer's low_latency_mode parameter always to True and conducted several tests. The results showed that the traffic became balanced.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
